### PR TITLE
Fixing text sizing as well as mobile screen size

### DIFF
--- a/jairo.css
+++ b/jairo.css
@@ -5,11 +5,11 @@
 .officer-grid{
   overflow:auto;
   padding: 10px;
-  height: 90vh;
+  height: 100vh;
   width: 100%;
   display: flex;
   flex-direction: row;
-  justify-content: space-evenly;
+  justify-content: space-around;
   flex-wrap: wrap;
 }
 .officer-grid div {
@@ -17,7 +17,7 @@
   box-sizing: border-box;
   text-align: center;
   width: 40%;
-  height: 35%;
+  height: 40%;
   padding: 2%;
 }
 
@@ -53,19 +53,21 @@
   .officer-grid{
     overflow:auto;
     padding: 5px;
-    height: 100vh;
+    height: 170vh;
     width: 100%;
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     justify-content: space-between;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
   }
 
   .officer-grid div {
+
     box-sizing: border-box;
     text-align: center;
-    width: 45%;
-    height: 40%;
+    align-self: center;
+    width: 80%;
+    height: 22%;
     padding: 2%;
   }
 


### PR DESCRIPTION
There seemed to be an issue with text going out of the box:
![Weird Text Bug](https://user-images.githubusercontent.com/54415437/142565814-9baa6d91-f463-4677-aad7-22ec438e83e6.png)

There was also an issue with officer positions as the screen got smaller, now officer + officer positions turn into a single column to make room.
